### PR TITLE
fix mut self context

### DIFF
--- a/src/gen_functions.rs
+++ b/src/gen_functions.rs
@@ -277,7 +277,7 @@ pub fn func_call_tkn(
             ParamType::SelfType => 
             func_call = quote! {
                 #func_call
-                #param_ident,
+                //#param_ident,
             },
             _ => if param.out_param {
                 func_call = quote! {
@@ -304,7 +304,7 @@ pub fn func_call_tkn(
     let mut func_call = if func.return_value.1 {
         quote! {
             #pre_call
-            let call_result = (self.#func_ident)(#func_call);
+            let call_result = self.#func_ident(#func_call);
             let Ok(call_result) = call_result else { return false; };
             #post_call
         }
@@ -312,7 +312,7 @@ pub fn func_call_tkn(
     else {
         quote! {
             #pre_call
-            let call_result = (self.#func_ident)(#func_call);
+            let call_result = self.#func_ident(#func_call);
             #post_call
         }
     };
@@ -501,12 +501,12 @@ fn gen_param_prep(param: &ArgumentDesc, param_ident: &Ident) -> (proc_macro2::To
             if param.out_param {
                 pre_call = quote! {
                     #pre_call
-                    let mut #param_ident = &mut self;
+                    //let mut #param_ident = &mut self;
                 };
             } else {
                 pre_call = quote! {
                     #pre_call
-                    let #param_ident = &self;
+                    //let #param_ident = &self;
                 };
             }
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,8 @@ fn build_impl_block(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Tok
 
         find_func_body = quote! {
             #find_func_body
-            if native_api_1c::native_api_1c_core::ffi::string_utils::os_string_nil(#name_literal) == name { return Some(#func_index) };
-            if native_api_1c::native_api_1c_core::ffi::string_utils::os_string_nil(#name_ru_literal) == name { return Some(#func_index) };
+            if name_str == #name_literal { return Some(#func_index) };
+            if name_str == #name_ru_literal { return Some(#func_index) };
         };
         get_func_name_body = quote! {
             #get_func_name_body
@@ -235,6 +235,8 @@ fn build_impl_block(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Tok
                 #number_of_func
             }
             fn find_method(&self, name: &[u16]) -> Option<usize> {
+                let name_string: String = native_api_1c::native_api_1c_core::ffi::string_utils::from_os_string(name);
+                let name_str: &str = name_string.as_str();
                 #find_func_body
                 None
             }

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -9,6 +9,8 @@ fn tests() {
     t.pass("tests/to_build/functions/date_type.rs");
     t.pass("tests/to_build/functions/blob_type.rs");
 
+    t.pass("tests/to_build/functions/mut_type.rs");
+
     t.pass("tests/to_build/functions/result/bool_type.rs");
     t.pass("tests/to_build/functions/result/int_type.rs");
     t.pass("tests/to_build/functions/result/float_type.rs");

--- a/tests/to_build/functions/mut_type.rs
+++ b/tests/to_build/functions/mut_type.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use native_api_1c::native_api_1c_core::ffi::connection::Connection;
+use native_api_1c_macro::AddIn;
+
+#[derive(AddIn)]
+pub struct MyAddIn {
+    #[add_in_con]
+    connection: Arc<Option<&'static Connection>>,
+
+    #[add_in_func(name = "MyFunction", name_ru = "МояФункция")]
+    #[arg(Str, as_out)]
+    #[returns(Str)]
+    pub my_function: fn(&Self, &mut String) -> String,
+
+    #[add_in_func(name = "MyFunction2", name_ru = "МояФункция2")]
+    #[arg(Str, as_out)]
+    #[returns(Str)]
+    pub my_function2: fn(&mut Self, &mut String) -> String,
+}
+
+impl MyAddIn {
+    pub fn new() -> Self {
+        Self {
+            connection: Arc::new(None),
+            my_function: Self::my_function,
+            my_function2: Self::my_function2,
+        }
+    }
+
+    fn my_function(&self, arg: &mut String) -> String {
+        *arg = "new string".into();
+        arg
+    }
+
+    fn my_function2(&mut self, arg: &mut String) -> String{
+        *arg = "new string".into();
+        arg
+    }
+}
+
+fn main() {
+    let _add_in = MyAddIn::new();
+}


### PR DESCRIPTION
Мы общались на инфостарте https://infostart.ru/1c/articles/1920565/. 
Я пробую реализовать драйвер внешнего оборудования для 1С и сразу огромное спасибо за out параметры!
Использую последние dev версии, то что еще не вошло в main ветку.
Столкнулся с невозможностью компиляции в случае если у меня одновременно есть out переменная и используется &mut Self

```
    #[add_in_func(name="Open", name_ru="Подключить")]
    #[arg(Str, as_out)] // DeviceID out
    #[returns(Bool, result)]
    pub open: fn(&mut Self, &mut String) -> Result<bool, ()>,
```

Макрос генерирует нечто подобное

```
if method_num == 5usize {
            ...
            let mut param_self = &mut self;
            ...
            let call_result = (self.open)(param_self, &mut param_1);
```

но как раз из-за присвоения mut param_self возникает ошибка владения, т.к. self уже &mut.

Простой пример этой ошибки
```
struct Driver{
    check: fn(&mut Self) -> bool,
    state: bool
}

impl Driver{
    fn new() -> Self {
        Self {
            state: false,
            check: Self::check
        }
    }
    fn check(&mut self) -> bool{
        self.state = true;
        return self.state
    }
    fn do_check(&mut self){
        // получается тип &mut &mut Driver
        let pself = &mut self; // !!!!cannot borrow `self` as mutable, as it is not declared as mutable  
        let result = (self.check)(pself);
        
        // а вот так работает
        //let pself = &self;
        //let result = self.check();
    }
}
```
Предлагаю один из вариантов как это обойти.

Требуется ревизия, т.к. это по сути мой первый опыт в rust.